### PR TITLE
Release 0.14.1 announcement

### DIFF
--- a/_posts/2022-05-23-renaissance-0-14-1.md
+++ b/_posts/2022-05-23-renaissance-0-14-1.md
@@ -1,0 +1,30 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.14.1 Released"
+author: Lubomír Bulej
+---
+
+We have released a bugfix update of the Renaissance benchmark suite, fixing two
+race conditions discovered in the `finagle-chirper` and `reactors` benchmarks.
+Apart from the bug fixes, there have been no other changes to the benchmark
+code or the underlying libraries. The changes in the affected benchmarks are
+relatively minor, and the unaffected benchmarks are identical to Renaissance
+0.14. Consequently, there should be no significant changes in the workloads.
+
+Both race conditions resulted in exceptions visible in the benchmark output,
+but only the exception in the `reactors` benchmark caused the benchmark to fail
+in a difficult-to-ignore deadlock. The exception in `finagle-chirper` caused a
+particular future computation to terminate prematurely, but that did not cause
+the entire benchmark to fail. We apologize for the inconvenience.
+
+More details can be found in the respective pull requests
+([#356](https://github.com/renaissance-benchmarks/renaissance/pull/356) and
+[#357](https://github.com/renaissance-benchmarks/renaissance/pull/357) in
+the case of `finagle-chirper`, and [#360](https://github.com/renaissance-benchmarks/renaissance/pull/360)
+in the case of `reactors`).
+
+
+Any comments and contributions are welcome.
+
+Happy benchmarking!


### PR DESCRIPTION
Initial draft. There is also a GitHub [draft release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/untagged-357244ecaf6b4eb2f495) with pointers to pull requests in the main project. Date-dependent file names and links will be updated to reflect the actual release date. 
