### PR TITLE
Release 0.14.2 announcement

### DIFF
--- a/_posts/2023-02-28-renaissance-0-14-2.md
+++ b/_posts/2023-02-28-renaissance-0-14-2.md
@@ -1,0 +1,29 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.14.2 Released"
+author: Lubomír Bulej
+---
+
+We have released a maintenance update of the Renaissance benchmark suite with
+two changes in the underlying libraries. One is to avoid packaging vulnerable
+versions of the `log4j` framework and the other is to improve compatibility 
+with the LoongArch64 processor architecture.
+
+Even though we believe that the Renaissance suite itself (and the way it is
+used) is not susceptible to the vulnerabilities, the presence of JAR files with
+vulnerable classes can trigger alarms from various security scanners in some
+environments. We have removed the `log4j` library from all (even transitive)
+dependencies and replaced it with the `reload4j` library where necessary. The
+logging configuration of the Apache Spark, Twitter Finagle, and Akka benchmarks
+was updated to restore the previous behavior.
+
+To improve compatibility with the LoongArch64 processor architecture, we 
+updated the JNA library to a version that includes support for the processor.
+
+See the pull requests referenced in the [GitHub release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.14.2) for more details.
+
+
+Any comments and contributions are welcome.
+
+Happy benchmarking!


### PR DESCRIPTION
Long-overdue maintenance release. There is also a GitHub [draft release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/untagged-e03139b3528e262253d9) with pointers to pull requests in the main project and release artifacts. The commit (and tag) with the release-related changes to the Renaissance repository are in my local repository and I will push it directly to the master branch when we pull the trigger. Date-dependent file names and links will be updated to reflect the actual release date (if necessary).