### PR TITLE
Release 0.15.0 announcement

### DIFF
--- a/_posts/2023-10-23-renaissance-0-15-0.md
+++ b/_posts/2023-10-23-renaissance-0-15-0.md
@@ -1,0 +1,41 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.15 Released"
+author: Lubomír Bulej
+---
+
+We are pleased to announce a new release of the Renaissance benchmark suite.
+This release is primarily aimed at improving compatibility with Java 21 (LTS)
+and Java 22 (EA), but it also marks the departure from Java 8 by requiring at
+least Java 11 to build the suite and to run the benchmarks. Several benchmarks
+now use Scala 3 and a memory leak was plugged in one of the benchmarks.
+
+To improve compatibility with Java 21, the Apache Spark framework used by the
+`apache-spark` benchmarks was updated to version 3.5.0 and the Neo4j framework
+used by the `neo4j-analytics` benchmark was updated to version 5.12.0 (the 
+benchmark now requires Java 17 to run). The database libraries used in the
+`db-shootout` benchmark were updated to more recent versions, which makes the
+benchmark compatible with Java 18 (while still far from Java 21, it is an
+improvement over Java 11, where the benchmark was stuck for some time).
+
+The Scala 2.12 and 2.13 versions used by various benchmarks were updated to
+versions 2.12.18 and 2.13.12, respectively. The `akka-uct`, `dotty`, and 
+`scala-kmeans` are now using Scala 3.3.1, and the `neo4j-analytics` benchmark
+now uses Scala 2.13. This leaves only the `philosophers`, `reactors` and
+`stala-stm-bench7` benchmarks in the Scala 2.12 camp.
+
+Even though the source code of most benchmarks remains unchanged (apart from
+bug fixes and changes due to library APIs), the actual code executed at runtime
+may be affected by the dependency updates.
+
+Other changes include a fix for a memory leak in the `reactors` benchmark, and
+two fixes that improve compatibility with JMH.
+
+See the pull requests referenced in the [GitHub release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.15.0) for more details.
+
+
+Any comments and contributions are welcome.
+
+Happy benchmarking!
+


### PR DESCRIPTION
There is also a GitHub [draft release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/untagged-6e3353cc5d0caad3a7b0) with release artifacts and pointers to pull requests in the main project. The commit (and tag) with the release-related changes to the Renaissance repository are in my local repository and I will push it directly to the master branch when we pull the trigger. Date-dependent file names and links will be updated to reflect the actual release date (if necessary).