### PR TITLE
Release 0.16.0 announcement

### DIFF
--- a/_posts/2024-11-22-renaissance-0-16-0.md
+++ b/_posts/2024-11-22-renaissance-0-16-0.md
@@ -1,0 +1,41 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.16 Released"
+author: Lubomír Bulej
+---
+
+We are pleased to announce a new release of the Renaissance benchmark
+suite. This release adds result validation to several benchmarks, improves
+compatibility with current Java releases, and updates numerous underlying
+frameworks and libraries.
+
+Validation was improved or added to the following 7 workloads: `als`,
+`fj-kmeans`, `future-genetic`, `gauss-mix`, `log-regression`, `movie-lens`,
+and `philosophers`, bringing Renaissance closer to having fully validated
+workloads (there are still 4 missing).
+
+Issues related to the Hadoop Client API library (which plagued the Apache
+Spark benchmarks) and the Chronicle Map library (which plagued the `db-shootout`
+benchmark) were resolved. As a result, all benchmarks in this release (with the
+exception of `neo4j-analytics` which requires at least version 17 to run), run
+on LTS versions from 11 to 21 as well as on early access version of Java 24.
+
+The `philosophers` and `scala-stm-bench7` benchmarks were migrated to Scala 3,
+continuing the migration towards more recent Scala versions. The `reactors`
+benchmark is the last to require Scala 2.12.
+
+Even though the source code of most benchmarks remains unchanged, the actual
+code executed at runtime may be affected by the dependency updates, resulting
+in different performance. Apart from the indirect impact of library updates,
+the performance of the `future-genetic`, `gauss-mix`, `movie-lens`, and
+`philosophers` benchmarks is known to differ from the previous release due
+to benchmark changes.
+
+See the [GitHub release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.16.0) for more details.
+
+
+Any comments and contributions are welcome.
+
+Happy benchmarking!
+


### PR DESCRIPTION
There is also a GitHub [draft release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/untagged-aec4a6b2af886db34ac4) with release artifacts and pointers to pull requests in the main project. The commit (and tag) with the release-related changes to the Renaissance repository are in my local repository and I will push it directly to the master branch when we pull the trigger. Date-dependent file names and links will be updated to reflect the actual release date (if necessary).