### PR TITLE
Release 0.16.1 announcement

### DIFF
--- a/_posts/2025-11-10-renaissance-0-16-1.md
+++ b/_posts/2025-11-10-renaissance-0-16-1.md
@@ -1,0 +1,27 @@
+---
+layout: mainpost
+projectname: Renaissance Suite
+title:  "Renaissance 0.16.1 Released"
+author: Lubomír Bulej
+---
+
+We have released a maintenance update of the Renaissance benchmark suite,
+mainly to address compatibility issues with the upcoming Java 26 release.
+Apart from minor changes to the non-timed parts of the `als` and `db-shootout`
+benchmarks, there have been no changes to benchmark code. Similarly, apart from
+patches to avoid accessing JDK internals removed in Java 26, there have been no
+dependency version updates.
+
+Other changes include harness updates to provide additional data in the output,
+loading of dependency JAR files from the main bundle without extracting them
+first, and more robust cleanup of the scratch directory on NFS. Finally, the
+suite documentation was updated to cover several known issues that require user
+intervention.
+
+See the [GitHub release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.16.1) for more details.
+
+
+Any comments and contributions are welcome.
+
+Happy benchmarking!
+


### PR DESCRIPTION
There is also a GitHub [release](https://github.com/renaissance-benchmarks/renaissance/releases/tag/v0.16.1) with downloadable artifacts and pointers to pull requests in the main project. The commit (and tag) with the release-related changes to the Renaissance repository are in my local repository and I will push it directly to the master branch when we pull the trigger. Date-dependent file names and links will be updated to reflect the actual release date.